### PR TITLE
Broken playbook relative paths for urls

### DIFF
--- a/docs/08-sikker-utvikling/baseimages.md
+++ b/docs/08-sikker-utvikling/baseimages.md
@@ -9,7 +9,7 @@ tags:
 
 Man kan redusere angrepsflaten sin betydelig ved å basere appen sin på et minimalt baseimage. Jo færre verktøy du har i containeren din, jo mindre spillerom har en angriper til å få fotfeste og eskalere sine rettigheter.
 
-De gamle [navikt-imagene](https://github.com/navikt/baseimages/) er avviklet og vedlikeholdes ikke lenger. Hvis du fortsatt bruker disse imagene er det på høy tid å bytte over til bedre og moderne alternativer som "[distroless](./containere#distroless)".
+De gamle [navikt-imagene](https://github.com/navikt/baseimages/) er avviklet og vedlikeholdes ikke lenger. Hvis du fortsatt bruker disse imagene er det på høy tid å bytte over til bedre og moderne alternativer som "[distroless](/docs/sikker-utvikling/containere#distroless)".
 
 Mange tror at det er vanskelig og/eller veldig tidkrevende å migrere over til nye og skinnende "distroless" images, men det er det faktisk ikke. Vi har derfor satt sammen en liste over de største forskjellene, og hvordan man bytter over fra gammelt til nytt.
 

--- a/docs/10-verktoy/dependabot.md
+++ b/docs/10-verktoy/dependabot.md
@@ -8,7 +8,7 @@ tags:
 
 **Relevante tema:**
 
-- [Tredjepartskode](../sikker-utvikling/tredjepartskode)
+- [Tredjepartskode](/docs/sikker-utvikling/tredjepartskode)
 
 [Dependabot](https://github.com/dependabot) er et verktøy som kan brukes på alle GitHub-repos. Dersom man ønsker at Dependabot kun skal sjekke etter sårbarheter, kan dette settes opp i dit repo i GitHub, under _Security_. Ønsker man å også få forslag til oppgraderinger som ikke nødvendigvis er sårbarheter, kan man be om det via `dependabot.yml`. Les mer om den siste varianten [her](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates).
 

--- a/docs/10-verktoy/github-advanced-security.md
+++ b/docs/10-verktoy/github-advanced-security.md
@@ -9,8 +9,8 @@ tags:
 
 **Relevante tema:**
 
-- [Statisk kodeanalyse](../sikker-utvikling/kodeanalyse)
-- [Tredjepartskode](../sikker-utvikling/tredjepartskode)
+- [Statisk kodeanalyse](/docs/sikker-utvikling/kodeanalyse)
+- [Tredjepartskode](/docs/sikker-utvikling/tredjepartskode)
 - [Hemmeligheter](/docs/sikker-utvikling/hemmeligheter)
 
 [GitHub Advanced Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security) er tilgjengelig og aktivert alle repoer under organisasjonene [navikt](https://github.com/navikt) og [nais](https://github.com/nais) på GitHub, og du skal ikke trenge gjøre noe for å kommme i gang.

--- a/docs/10-verktoy/nais-console-dp-track.md
+++ b/docs/10-verktoy/nais-console-dp-track.md
@@ -11,7 +11,7 @@ tags:
 
 - [Sikkerhet i og rundt containere](/docs/sikker-utvikling/containere)
 - [Tredjepartskode](/docs/sikker-utvikling/tredjepartskode)
-- [Trivy](/docs/10-verktoy/trivy.md)
+- [Trivy](/docs/verktoy/trivy)
 
 ## NAIS Console
 

--- a/docs/10-verktoy/nais-console-dp-track.md
+++ b/docs/10-verktoy/nais-console-dp-track.md
@@ -9,9 +9,9 @@ tags:
 
 **Relevante tema:**
 
-- [Sikkerhet i og rundt containere](../sikker-utvikling/containere)
-- [Tredjepartskode](../sikker-utvikling/tredjepartskode)
-- [Trivy](./trivy)
+- [Sikkerhet i og rundt containere](/docs/sikker-utvikling/containere)
+- [Tredjepartskode](/docs/sikker-utvikling/tredjepartskode)
+- [Trivy](/docs/10-verktoy/trivy.md)
 
 ## NAIS Console
 

--- a/docs/10-verktoy/trivy.md
+++ b/docs/10-verktoy/trivy.md
@@ -10,7 +10,7 @@ tags:
 
 **Relevante tema:**
 
-- [Sikkerhet i og rundt containere](../sikker-utvikling/containere)
+- [Sikkerhet i og rundt containere](/docs/sikker-utvikling/containere)
 
 [Trivy fra aquasecurity](https://github.com/aquasecurity/trivy) er ett verktøy for å finne sårbarheter, hemmeligheter & feilkonfigurasjon.
 Ved å integrere Trivy med GitHub Actions kan du skanne Docker-images for sårbarheter & hemmeligheter i både OS og applikasjon samt laste opp resultatene til Github Advanced Security for å få alerts i "Code Scanning"-seksjonen.

--- a/docs/10-verktoy/zizmor.md
+++ b/docs/10-verktoy/zizmor.md
@@ -9,7 +9,7 @@ tags:
 
 **Relevante tema:**
 
-- [Statisk analyse](../sikker-utvikling/kodeanalyse)
+- [Statisk analyse](/docs/sikker-utvikling/kodeanalyse)
 
 [zizmor](https://woodruffw.github.io/zizmor) er et statisk analyseverktøy for GitHub Actions.
 Den kan finne mange vanlige sikkerhetsproblemer i GitHub Actions.

--- a/docs/security-champion-rolle.md
+++ b/docs/security-champion-rolle.md
@@ -22,7 +22,7 @@ For å bli security champion trenger man ikke å være ekspert på sikkerhet, me
 
 ### Anbefalte praktiske aktiviter
 
-- Følge opp varsler fra [Dependabot](https://github.com/dependabot). Se [Tredjepartskode](/docs/08-sikker-utvikling/tredjepartskode.md)
+- Følge opp varsler fra [Dependabot](https://github.com/dependabot). Se [Tredjepartskode](/docs/sikker-utvikling/tredjepartskode)
 - Følge med på Slack-kanalen [#security-champion](https://nav-it.slack.com/archives/CN8N938K1) og [andre relevante Slack-kanaler](./lenker.md#slack-kanaler)
 
 Flere praktiske aktiviteter finnes på siden [«Ny Security Champion»](/docs/ny-security-champion).

--- a/docs/security-champion-rolle.md
+++ b/docs/security-champion-rolle.md
@@ -22,7 +22,7 @@ For å bli security champion trenger man ikke å være ekspert på sikkerhet, me
 
 ### Anbefalte praktiske aktiviter
 
-- Følge opp varsler fra [Dependabot](https://github.com/dependabot). Se [Tredjepartskode](./08-sikker-utvikling/tredjepartskode.md)
+- Følge opp varsler fra [Dependabot](https://github.com/dependabot). Se [Tredjepartskode](/docs/08-sikker-utvikling/tredjepartskode.md)
 - Følge med på Slack-kanalen [#security-champion](https://nav-it.slack.com/archives/CN8N938K1) og [andre relevante Slack-kanaler](./lenker.md#slack-kanaler)
 
 Flere praktiske aktiviteter finnes på siden [«Ny Security Champion»](/docs/ny-security-champion).


### PR DESCRIPTION
Links break when page is refreshed and browser adds a trailing slash. Made links absolute instead.