### PR TITLE
docs: oppdater nav-pilot-eksemplene til én agentpakke

### DIFF
--- a/docs/10-verktoy/github-copilot.md
+++ b/docs/10-verktoy/github-copilot.md
@@ -23,15 +23,13 @@ Verktøyene er bygget som _agenter_, _skills_ og _instruksjoner_ som Copilot bru
 
 ## Kom i gang
 
-Installer [nav-pilot](https://github.com/navikt/copilot) og velg en samling som passer prosjektet ditt. Sikkerhetsverktøyene følger med automatisk.
+Installer [nav-pilot](https://github.com/navikt/copilot). Alt innhold ligger nå i én agentpakke, og sikkerhetsverktøyene følger med automatisk.
 
 ```bash
 brew install navikt/tap/nav-pilot
 
-# Installer en samling (inkluderer sikkerhetsverktøy)
-nav-pilot install kotlin-backend   # Kotlin/Ktor/Spring Boot
-nav-pilot install fullstack        # Kotlin + Next.js
-nav-pilot install platform         # Plattform og infrastruktur
+# Installer agentpakka (inkluderer sikkerhetsverktøy)
+nav-pilot install nav-pilot
 ```
 
 Etter installasjon kan du bruke verktøyene i VS Code, JetBrains eller terminalen:
@@ -132,15 +130,15 @@ I stedet for å starte fra bunnen av kan du bruke `@security-champion` til å ge
 
 Agenten lager et strukturert resultat med trusler, alvorlighetsgrad og konkrete tiltak — klart til gjennomgang med teamet.
 
-## Samlinger og innhold
+## Sikkerhetsinnhold i agentpakka
 
-Alle samlinger inkluderer sikkerhetsverktøy. Her er hva som følger med:
+Agentpakka inkluderer alt sikkerhetsinnholdet, og du kan velge bort det du ikke trenger i velgeren ved installasjon:
 
-| Samling | Agenter | Skills | Instruksjoner |
-|---------|---------|--------|---------------|
-| `kotlin-backend` | security-champion | security-review, threat-model | security-owasp |
-| `fullstack` | security-champion | security-review, threat-model, tokenx-auth | security-owasp |
-| `platform` | security-champion | security-review, threat-model, workstation-security | security-owasp |
+| Type | Innhold |
+|------|---------|
+| Agenter | security-champion |
+| Skills | security-review, threat-model, tokenx-auth, workstation-security |
+| Instruksjoner | security-owasp |
 
 ## Lenker
 

--- a/docs/10-verktoy/github-copilot.md
+++ b/docs/10-verktoy/github-copilot.md
@@ -36,7 +36,7 @@ Etter installasjon kan du bruke verktøyene i VS Code, JetBrains eller terminale
 
 ```
 @security-champion Trusselmodeller denne tjenesten
-@auth-agent Hvordan setter jeg opp TokenX for denne appen?
+@nav-pilot Bruk $nav-auth til å sette opp TokenX for denne appen
 @nav-pilot Jeg trenger en ny tjeneste som håndterer søknader
 ```
 
@@ -56,21 +56,6 @@ En agent som hjelper med trusselmodellering, GDPR-vurderinger og sikkerhetsarkit
 @security-champion Hva er de viktigste sikkerhetstruslene for en Kafka-basert hendelsesstrøm?
 ```
 
-### @auth-agent
-
-En agent som kjenner alle autentiserings- og autorisasjonsmekanismer i Nav:
-
-- **Azure AD**: Ansattinnlogging, JWT-validering, gruppebasert tilgangsstyring
-- **TokenX**: Tjeneste-til-tjeneste med brukerkontekst, token exchange
-- **ID-porten + Wonderwall**: Innbyggerinnlogging med OIDC
-- **Maskinporten**: Maskin-til-maskin for eksterne parter
-- **JWT-claims**: Validering av `iss`, `aud`, `exp`, `azp` og pre-authorized apps
-
-```
-@auth-agent Hvordan validerer jeg et TokenX-token i Ktor?
-@auth-agent Hvilken auth-mekanisme trenger jeg for maskin-til-maskin mot et eksternt API?
-```
-
 ## Sikkerhetsskills
 
 Skills er kunnskapspakker som agentene bruker, men som du også kan referere til direkte.
@@ -81,6 +66,25 @@ Skills er kunnskapspakker som agentene bruker, men som du også kan referere til
 | `$threat-model` | STRIDE-A trusselmodellering med dataflytdiagram og Nav-spesifikke tillitsgrenser |
 | `$workstation-security` | Sikkerhetssjekk av utviklermaskinen: FileVault, brannmur, SSH, Git-credentials, naisdevice |
 | `$tokenx-auth` | Implementasjonsguide for TokenX token exchange med Ktor, caching og testing |
+| `$nav-auth` | Autentisering og autorisasjon i Nav: Azure AD, TokenX, ID-porten, Maskinporten og JWT-validering |
+
+### $nav-auth
+
+Skillen dekker autentiserings- og autorisasjonsmønstrene for Nav-applikasjoner på Nais. Den er ment for deg som legger til autentisering i en app, kaller en annen tjeneste med TokenX, validerer JWT-er, setter opp maskin-til-maskin med Maskinporten eller feilsøker autentisering som ikke virker.
+
+- **Azure AD**: Ansattinnlogging med Nais-konfigurasjon, miljøvariablene som injiseres, og JWT-validering i Ktor og i Next.js med `@navikt/oasis`
+- **TokenX**: Tjeneste-til-tjeneste med brukerkontekst, token exchange i Kotlin og TypeScript, og `accessPolicy` for inn- og utgående trafikk
+- **ID-porten**: Innbyggerinnlogging via sidecar, der applikasjonen får en ferdig validert JWT
+- **Maskinporten**: Maskin-til-maskin for eksterne organisasjoner, med scopes i Nais-manifestet
+- **JWT-validering**: Issuer, audience, utløpstid og signatur, og validering av `azp` mot `AZURE_APP_PRE_AUTHORIZED_APPS` for M2M-tokener
+- **Testing**: MockOAuth2Server i Kotlin og Vitest i TypeScript
+
+Skillen ber deg også holde autentiseringskoden og `accessPolicy.inbound.rules` i Nais-manifestet i takt, slik at alt som slipper gjennom på nettverksnivå også valideres på token-nivå.
+
+```
+@nav-pilot Bruk $nav-auth til å validere et TokenX-token i Ktor
+@nav-pilot Bruk $nav-auth til å finne riktig auth-mekanisme for maskin-til-maskin mot et eksternt API
+```
 
 ## Sikkerhetsinstruksjoner
 
@@ -137,7 +141,7 @@ Agentpakka inkluderer alt sikkerhetsinnholdet, og du kan velge bort det du ikke 
 | Type | Innhold |
 |------|---------|
 | Agenter | security-champion |
-| Skills | security-review, threat-model, tokenx-auth, workstation-security |
+| Skills | security-review, threat-model, nav-auth, tokenx-auth, workstation-security |
 | Instruksjoner | security-owasp |
 
 ## Lenker


### PR DESCRIPTION
## Hvorfor nå

navikt/copilot#670 kollapser nav-pilots fem samlinger (`frontend`, `fullstack`, `kotlin-backend`, `nextjs-frontend`, `platform`) til én agentpakke. Etter merge avvises `nav-pilot install kotlin-backend` og de andre samlingsnavnene med en feilmelding som peker på den nye kommandoen, og lesere av denne siden ville truffet den avvisningen.

I tillegg beskrev sida fortsatt agenten `@auth-agent`. Den agenten finnes ikke lenger: `auth`, `nais` og `observability` ble pensjonert 31. august 2026, og innholdet migrert inn i skillene `nav-auth` og `observability-setup` (navikt/copilot#481, se `docs/nav-pilot-changelog.md`).

## Hva som er endret

Kun `docs/10-verktoy/github-copilot.md`:

- Install-eksemplene bruker nå den nye kommandoen: `nav-pilot install nav-pilot`
- «Samlinger og innhold»-tabellen er erstattet med én oversikt over sikkerhetsinnholdet i agentpakka (innholdet kan fortsatt velges bort i velgeren ved installasjon)
- `### @auth-agent` under «Sikkerhetsagenter» er fjernet og erstattet av en beskrivelse av skillen `$nav-auth` under «Sikkerhetsskills», med egen tabellrad. Prompt-eksemplet i «Kom i gang» bruker skillen i stedet for agenten
- `nav-auth` er lagt til i oversikten over sikkerhetsinnholdet i agentpakka

## Om beskrivelsen av `$nav-auth`

Skrevet ut fra `skills/nav-auth/SKILL.md` på navikt/copilot main, ikke ut fra den gamle agentteksten. Skillen dekker Azure AD, TokenX, ID-porten, Maskinporten, JWT-validering (issuer, audience, utløp, signatur, og `azp` mot `AZURE_APP_PRE_AUTHORIZED_APPS` for M2M) og testoppsett med MockOAuth2Server og Vitest. Utløsertilfellene i «When to Use» er gjengitt i teksten.

`$nav-auth` og `$tokenx-auth` er to ulike skills som begge finnes i dag. Tabellradene skiller dem: `nav-auth` er den brede auth-skillen, `tokenx-auth` er implementasjonsguiden for selve token exchange-flyten.

Den gamle agentteksten sa «ID-porten + Wonderwall». `nav-auth` omtaler bare ID-porten-sidecaren, så teksten er justert deretter.

## Verifisert

- Den nye kommandoen og de fem utgåtte samlingsnavnene er verifisert mot diffen i navikt/copilot#670 (`docs/README.nav-pilot.md`, `scripts/install.sh` og `cli/nav-pilot/internal/agentpakke/legacy.go`)
- Sikkerhetsartefaktene i tabellen er verifisert mot innholdet på #670-grenen
- `skills/nav-auth/` og `skills/tokenx-auth/` finnes begge på navikt/copilot main; `agents/` inneholder ingen auth-agent
- `pnpm test` (Docusaurus-bygg) kjører grønt lokalt, både direkte og via pre-commit-hooken

Endringen er kun dokumentasjon.